### PR TITLE
Go back to old name for NO CONVERTER state because new name breaks ol…

### DIFF
--- a/test/pact-verify.ts
+++ b/test/pact-verify.ts
@@ -61,7 +61,7 @@ async function buildOptions(): Promise<VerifierOptions> {
       console.log('A Mock converter will be used.');
       Container.bind(ConverterApi).scope(Scope.Singleton).to(MockConverter);
     },
-    'WITHOUT CONVERTER': () => {
+    'NO CONVERTER': () => {
       console.log('Expect errors and delays with any converter call.');
       Container.bind(ConverterApi).scope(Scope.Singleton).to(MockNoConverter);
     },


### PR DESCRIPTION
…d pact